### PR TITLE
Only use M73 estimation after getting first M73.

### DIFF
--- a/octoprint_m73etaoverride/__init__.py
+++ b/octoprint_m73etaoverride/__init__.py
@@ -3,7 +3,7 @@ import octoprint.plugin
 import re
 from octoprint.printer.estimation import PrintTimeEstimator
 
-m73time = 1
+m73time = None
 
 class M73ETA(octoprint.plugin.OctoPrintPlugin,octoprint.plugin.RestartNeedingPlugin,octoprint.plugin.ReloadNeedingPlugin):
   def handle_m73(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
@@ -30,10 +30,14 @@ class M73ETA(octoprint.plugin.OctoPrintPlugin,octoprint.plugin.RestartNeedingPlu
 
 class M73PrintTimeEstimator(PrintTimeEstimator):
   def __init__(self, job_type):
-    pass
+    super(M73PrintTimeEstimator, self).__init__(job_type)
 
   def estimate(self, progress, printTime, cleanedPrintTime, statisticalTotalPrintTime, statisticalTotalPrintTimeType):
     global m73time
+
+    if m73time == None:
+      return super(M73PrintTimeEstimator, self).estimate(progress, printTime, cleanedPrintTime, statisticalTotalPrintTime, statisticalTotalPrintTimeType)
+
     estimates = 60 * int(m73time)
     return estimates, "estimate"
 


### PR DESCRIPTION
M73-based estimation currently always overrides the default Octoprint estimation, even if there are no M73 commands in the gcode.

This commit ensures that the default Octoprint estimation is used until the first M73 command is received, at which point it switches over.

This allows gcode from slicers without M73 support to be used with meaningful estimates and without having to disable the plugin.